### PR TITLE
Added 'use strict' to loader

### DIFF
--- a/loader.js
+++ b/loader.js
@@ -1,3 +1,4 @@
+'use strict';
 const gql = require('./');
 
 // Takes `source` (the source GraphQL query string)


### PR DESCRIPTION
Added 'use strict'; to loader.js so that we can use this package with node v4.  See #39